### PR TITLE
Point to latest BPM for Discord release

### DIFF
--- a/Manechat/index.html
+++ b/Manechat/index.html
@@ -25,6 +25,38 @@
 			selected_nav = name;
 		}
 	</script>
+	<script type="text/javascript">
+		document.addEventListener('DOMContentLoaded', function() {
+			var releasesUrl = 'https://api.github.com/repos/ByzantineFailure/BPM-for-Discord/releases';
+			var xhr = new XMLHttpRequest();
+			xhr.open('GET', releasesUrl);
+			xhr.onreadystatechange = function() {
+				if(xhr.readyState != 4) return;
+				if(xhr.status !== 200 && xhr.status !== 304) {
+					return;
+				}
+				var response = JSON.parse(xhr.responseText);
+				var release = response
+					.filter(function(release) {
+						return !release.prerelease;
+					})
+					.sort(function(a, b) {
+						var aDate = new Date(a.created_at);
+						var bDate = new Date(b.created_at);
+						if(aDate > bDate) {
+							return -1;
+						} else if (bDate > aDate) {
+							return 1;
+						} else {
+							return 0;
+						}
+					})
+					[0];
+				document.getElementById('discord-for-bpm-link').href = release.html_url;    
+			}
+			xhr.send(null);
+		});
+	</script>
 </head>
 <body>
 	<header>
@@ -98,7 +130,7 @@
   		</ul>
 		<strong>For the Discord DESKTOP CLIENT:</strong>
 		<ul>
-			<li>Download and extract <a href="https://goo.gl/nj1If2">this zip file</a>, which contains the BPM mod for Discord.</li>
+			<li>Download and extract <a id="discord-for-bpm-link" href="https://goo.gl/nj1If2">this 7zip archive (bottom of the page)</a>, which contains the BPM mod for Discord.</li>
 			<li>For instructions on how to install the mod, follow the guide shown on <a href="https://goo.gl/2I2R1B">this gif</a> or simply unzip the pack and read the README provided.</li>
 		</ul>
 	</article>


### PR DESCRIPTION
Points the link on the BPM for Discord page to the latest release of BPM for Discord.  In the event github is down it changes nothing.

This code will not function in IE8 and lower (all other major browsers will support it no problem).  However, because it is executed _after_ the core tab selection code all that'll happen is a console error is logged and the default link is pointed it.